### PR TITLE
Fixed memory leak

### DIFF
--- a/QRCodeEncoderObjectiveCAtGithub/QREncoder.h
+++ b/QRCodeEncoderObjectiveCAtGithub/QREncoder.h
@@ -30,3 +30,5 @@ const static unsigned char WHITE =  0xff;
 + (UIImage*)renderDataMatrix:(DataMatrix*)matrix imageDimension:(int)imageDimension;
 
 @end
+
+void FLProviderReleaseData(void *info, const void *data, size_t size);

--- a/QRCodeEncoderObjectiveCAtGithub/QREncoder.mm
+++ b/QRCodeEncoderObjectiveCAtGithub/QREncoder.mm
@@ -132,7 +132,7 @@
     CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, 
                                                               rawData, 
                                                               rawDataSize, 
-                                                              NULL);
+                                                              FLProviderReleaseData);
     
     CGColorSpaceRef colorSpaceRef = CGColorSpaceCreateDeviceRGB();
     CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault;
@@ -156,5 +156,8 @@
     return newImage;
 }
 
+void FLProviderReleaseData(void *info, const void *data, size_t size) {
+    free((void *)data);
+}
 
 @end


### PR DESCRIPTION
The image data is not released after object deallocation. This causes massive memory leaks. I added a callback function to fix this.
