### PR TITLE
Add deployment target to avoid build error for cocoapods 1.0.0

### DIFF
--- a/QR-Code-Encoder-for-Objective-C.podspec
+++ b/QR-Code-Encoder-for-Objective-C.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |spec|
         :tag => '80a5af09041673de6bdbd72fb93c9b95bf1b439e' }
     spec.source_files = 'QRCodeEncoderObjectiveCAtGithub/**/*.{h,m,mm,cpp}'
     spec.requires_arc = false
+    spec.ios.deployment_target = '5.0'
 end
 
 


### PR DESCRIPTION
libc++ requires iOS 5.0 or later, so update podspec.
